### PR TITLE
Space check

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -687,8 +687,12 @@ def main(upstream_channel, target_directory, temp_directory, platform,
                 channel=channel,
                 platform=platform,
                 file_name=package_name)
-            _download(url, download_dir)
-            summary['downloaded'].add((url, download_dir))
+            try:
+              _download(url, download_dir)
+              summary['downloaded'].add((url, download_dir))
+            except:
+              logger.error('Unexpected error: %s. Aborting download.', sys.exc_info()[0])
+              break
 
         # validate all packages in the download directory
         validation_results = _validate_packages(packages, download_dir,

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -26,7 +26,7 @@ DEFAULT_PLATFORMS = ['linux-64',
                      'win-64',
                      'win-32']
 
-MINIMUM_FREE_SPACE_MB = 100
+MINIMUM_FREE_SPACE_MB = 1000
 
 def _maybe_split_channel(channel):
     """Split channel if it is fully qualified.

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -735,7 +735,7 @@ def main(upstream_channel, target_directory, temp_directory, platform,
 
                 summary['downloaded'].add((url, download_dir))
             except Exception as ex:
-                logger.error('Unexpected error: %s. Aborting download.', ex)
+                logger.exception('Unexpected error: %s. Aborting download.', ex)
                 break
 
         # validate all packages in the download directory

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -26,6 +26,7 @@ DEFAULT_PLATFORMS = ['linux-64',
                      'win-64',
                      'win-32']
 
+MINIMUM_FREE_SPACE_MB = 100
 
 def _maybe_split_channel(channel):
     """Split channel if it is fully qualified.
@@ -678,6 +679,10 @@ def main(upstream_channel, target_directory, temp_directory, platform,
     with tempfile.TemporaryDirectory(dir=temp_directory) as download_dir:
         logger.info('downloading to the tempdir %s', download_dir)
         for package_name in sorted(to_mirror):
+            disk = os.statvfs(download_dir)
+            if ((disk.f_bavail * disk.f_frsize) / (1024 * 1024)) < MINIMUM_FREE_SPACE_MB:
+              logger.error('Disk space below threshold in %s. Aborting download.', download_dir)
+              break
             url = download_url.format(
                 channel=channel,
                 platform=platform,

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -734,8 +734,8 @@ def main(upstream_channel, target_directory, temp_directory, platform,
                     break
 
                 summary['downloaded'].add((url, download_dir))
-            except BaseException:
-                logger.error('Unexpected error: %s. Aborting download.', sys.exc_info()[0])
+            except Exception as ex:
+                logger.error('Unexpected error: %s. Aborting download.', ex)
                 break
 
         # validate all packages in the download directory


### PR DESCRIPTION
By default conda-mirror will continue pulling files until it either succeeds or dies from some sort of error.
This change aborts downloads with a logger.error when a threshold is reached.