### PR TITLE
conda_mirror.py: log download errors instead of breaking and clearing…

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -683,11 +683,11 @@ def main(upstream_channel, target_directory, temp_directory, platform,
                 platform=platform,
                 file_name=package_name)
             try:
-              _download(url, download_dir)
-              summary['downloaded'].add((url, download_dir))
-            except:
-              logger.error('Unexpected error: %s. Aborting download.', sys.exc_info()[0])
-              break
+                _download(url, download_dir)
+                summary['downloaded'].add((url, download_dir))
+            except Exception as ex:
+                logger.exception('Unexpected error %s: Aborting download', ex)
+                break
 
         # validate all packages in the download directory
         validation_results = _validate_packages(packages, download_dir,

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -682,8 +682,12 @@ def main(upstream_channel, target_directory, temp_directory, platform,
                 channel=channel,
                 platform=platform,
                 file_name=package_name)
-            _download(url, download_dir)
-            summary['downloaded'].add((url, download_dir))
+            try:
+              _download(url, download_dir)
+              summary['downloaded'].add((url, download_dir))
+            except:
+              logger.error('Unexpected error: %s. Aborting download.', sys.exc_info()[0])
+              break
 
         # validate all packages in the download directory
         validation_results = _validate_packages(packages, download_dir,


### PR DESCRIPTION
By default conda-mirror will continue pulling files until it either succeeds or dies from some sort of error.
If an error is encountered, all downloaded files residing in "temp space" will be deleted.

This change logs exceptions that occur during download so that the files that actually download successfully will be verified and moved to the target folder.