### PR TITLE
conda_mirror.py: corrected numbering in output when validating

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -507,7 +507,7 @@ def _validate_or_remove_package(args):
         return _remove_package(package_path, reason=reason)
     # validate the integrity of the package, the size of the package and
     # its hashes
-    logger.info('Validating {:4d} of {:4d}: {}.'.format(num, num_packages,
+    logger.info('Validating {:4d} of {:4d}: {}.'.format(num + 1, num_packages,
                                                         package))
     package_path = os.path.join(package_directory, package)
     return _validate(package_path,


### PR DESCRIPTION
When validating packages 'num' of 'count' is logged as the progress indicator.
Num being the position of the package in a zero based list gives the output: "Validating 0 of 5" packages, stopping av "4 of 5".
This fix adds +1 to num so the first of five packages gives "1 of 5" and the validation process ends with 5 of 5 packages.